### PR TITLE
Added slot for openstack hypervisor snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,3 +45,9 @@ parts:
     source: snap-wrappers/
     organize:
       "*": commands/
+
+plugs:
+  consul-socket:
+    interface: content
+    content: consul-unix-sock
+    target: $SNAP_DATA


### PR DESCRIPTION
Added slot for interfacing between snap-openstack-hypervisor and consul-client-operator to enable UNIX socket communication.