### PR TITLE
Update snap for Ubuntu 26.04 and Gazpacho 2026.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,8 +3,9 @@ summary: Consul is a tool for service discovery, monitoring and configuration.
 description: |
   Consul is a distributed, highly available, and data center aware solution to
   connect and configure applications across dynamic, distributed infrastructure.
-base: core24
-version: "1.19.2"
+base: core26
+build-base: devel
+version: "1.22.5"
 license: BUSL-1.1
 
 grade: devel # still needing to develop this snap further
@@ -35,7 +36,7 @@ parts:
     plugin: make
     source-type: git
     source: https://github.com/hashicorp/consul.git
-    source-tag: "v1.19.2"
+    source-tag: "v1.22.5"
     override-build: |
       set -eux
       cd $CRAFT_PART_SRC


### PR DESCRIPTION
Target Ubuntu 26.04 LTS with OpenStack Gazpacho:
- Bump snap base from core24 to core26
- Update Consul version from 1.19.2 to 1.22.5